### PR TITLE
Update promotion

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -14,6 +14,8 @@ import os
 import sys
 import logging
 from flask import Flask, jsonify, request, url_for, make_response, abort
+
+from tests.test_routes import CONTENT_TYPE_JSON
 from . import status  # HTTP Status Codes
 from werkzeug.exceptions import NotFound
 
@@ -95,6 +97,32 @@ def delete_promotions(promotion_id):
 
     app.logger.info("Promotion with ID [%s] delete complete.", promotion_id)
     return make_response("", status.HTTP_204_NO_CONTENT)
+
+@app.route("/promotions/<int:promotion_id>", methods=["PUT"])
+def update_promotions(promotion_id):
+    """
+    Update promotion value
+    This endpoint updates the promotion value of a promotion currently stored in database.
+
+    Args:
+        promotion_id (int): the id of promotion in integer
+    """
+    app.logger.info("Request to update promotion with id: %s; ", promotion_id)
+    check_content_type(CONTENT_TYPE_JSON)
+
+    promotion: Promotion = Promotion.find(promotion_id)
+    if not promotion:
+        raise NotFound(
+            "Cannot find promotion with id {}. ".format(promotion_id)
+        )
+    
+    promotion.deserialize(request.get_json())
+    promotion.update()
+    app.logger.info("Promotion with id {} has been updated.".format(promotion_id))
+    message = promotion.serialize()
+
+    return make_response(jsonify(message), status.HTTP_200_OK)
+
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -92,6 +92,28 @@ class TestPromotion(unittest.TestCase):
         promo.delete()
         self.assertEqual(len(Promotion.all()), 0)
 
+    def test_update_promotion(self):
+        """ Update a promotion """
+        promotion = PromotionFactory()
+        logging.debug(promotion)
+        promotion.create()
+        logging.debug(promotion)
+        self.assertEqual(promotion.id, 1)
+        # Change it an save it
+        promotion.value = 0.2
+        promotion_name = "hello"
+        promotion.name = promotion_name
+        original_id = promotion.id
+        promotion.update()
+        self.assertEqual(promotion.id, original_id)
+        # Fetch it back and make sure the id hasn't changed
+        # but the data did change
+
+        promotions = Promotion.all()
+        self.assertEqual(len(promotions), 1)
+        self.assertEqual(promotions[0].id, 1)
+        self.assertEqual(promotions[0].name, promotion_name)
+        self.assertEqual(promotions[0].value, 0.2)
     def test_find_promotion_by_name(self):
         """Find a Promotion by Name"""
         Promotion(name="Summer Sale",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -152,3 +152,37 @@ class TestPromotionServer(TestCase):
             "{0}/{1}".format(BASE_URL, test_promotion.id), content_type=CONTENT_TYPE_JSON
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_promotion(self):
+        """Update a Promotion"""
+        # create a promotion to update
+        test_promotion = PromotionFactory()
+        resp = self.app.post(
+            BASE_URL, json=test_promotion.serialize(), content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # update the promotion
+        new_promotion = resp.get_json()
+        logging.debug(new_promotion)
+        new_promotion["value"] = 0.2
+        promotion_name = "hello"
+        new_promotion["name"] = promotion_name
+        resp = self.app.put(
+            "/promotions/{}".format(new_promotion["id"]),
+            json=new_promotion,
+            content_type=CONTENT_TYPE_JSON,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        updated_promotion = resp.get_json()
+        self.assertEqual(updated_promotion["value"], 0.2)
+        self.assertEqual(updated_promotion["name"], promotion_name)
+    
+        # Attempt to update non-existing promotion
+        resp = self.app.put(
+            "/promotions/{}".format(2022),
+            json=new_promotion,
+            content_type=CONTENT_TYPE_JSON,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+    


### PR DESCRIPTION
Update promotion code added with test cases. All test cases passed with code coverage 100% in routes.py.

start_date and end_date in Promotion now accepts time format without timezone. If timezone is not specified in string like "01-01-2022 00:00:00", it is equivalent to "01-01-2022 00:00:00 +0000" (default to UTC).